### PR TITLE
use neondatabase-labs/docker-login-with-retries-action

### DIFF
--- a/docker-registry-login/action.yaml
+++ b/docker-registry-login/action.yaml
@@ -20,6 +20,9 @@ inputs:
     required: false
     default: '15'
 
+# NOTE: as short term fix we refer to commit in 'feat/add-retries' branch
+# Merging PR will lead to conflicts when we want to sync fork.
+# So for long term we should decide how to go there.
 runs:
   using: 'composite'
 

--- a/docker-registry-login/action.yaml
+++ b/docker-registry-login/action.yaml
@@ -7,30 +7,28 @@ inputs:
     required: false
   username:
     description: 'Username for given registry or DockerHub'
-    requred: false
+    required: false
   password:
     description: 'Password or preferably PAT for "username"'
     required: false
   attempt_limit:
     description: 'Maximum number of total attempts'
     required: false
-    default: 3
+    default: '3'
   attempt_delay:
     description: 'Delay between attempts'
     required: false
-    default: 3000
+    default: '15'
 
 runs:
   using: 'composite'
 
   steps:
     - name: Log in to Docker registry
-      uses: Wandalen/wretry.action/main@8ceaefd717b7cdae4f2637f9a433242ade421a0a  # 3.7.2
+      uses: neondatabase-labs/docker-login-with-retries-action@810869f3bbbd52c1784a14b06c868bffb13222c9
       with:
-        attempt_limit: ${{ inputs.attempt_limit }}
-        attempt_delay: ${{ inputs.attempt_delay }}
-        action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # 3.3.0
-        with: |
-          username: ${{ inputs.username }}
-          password: ${{ inputs.password }}
-          registry: ${{ inputs.registry }}
+        max-attempts: ${{ inputs.attempt_limit }}
+        retry-timeout: ${{ inputs.attempt_delay }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+        registry: ${{ inputs.registry }}


### PR DESCRIPTION
we have some issue with `Wandalen/retry.action` due to root-owned leftovers in `_work/_actions` folder, so we try ways without it