### PR TITLE
impr(release-pr): support Python 3.10 and fix cherry-pick parsing in composite action

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"

--- a/release-pr/action.yml
+++ b/release-pr/action.yml
@@ -52,8 +52,9 @@ runs:
           neon_release_pr_args+=( --hotfix )
         fi
 
-        if [[ -n "${{ inputs.cherry-pick }}" ]]; then
-          echo '${{ inputs.cherry-pick }}' | jq -r '.[]' | while read -r commit; do
+        if [[ -n '${{ inputs.cherry-pick }}' ]]; then
+          readarray -t commits < <(echo '${{ inputs.cherry-pick }}' | jq -r '.[]')
+          for commit in "${commits[@]}"; do
             neon_release_pr_args+=( --cherry-pick "$commit" )
           done
         fi

--- a/release-pr/pyproject.toml
+++ b/release-pr/pyproject.toml
@@ -6,7 +6,8 @@ readme = "README.md"
 authors = [
     { name = "JC Grünhage", email = "jc@neon.tech" }
 ]
-requires-python = ">=3.11"
+# 3.10 is required for ubuntu-22.04
+requires-python = ">=3.10"
 dependencies = [
     "rich>=14.0.0",
     "typer[all]>=0.15.2",

--- a/release-pr/uv.lock
+++ b/release-pr/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 
 [[package]]
 name = "click"
@@ -109,6 +109,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload_time = "2025-03-30T14:15:14.23Z" }
 wheels = [


### PR DESCRIPTION
Testing the workflows for https://github.com/neondatabase/neon/pull/11679 in https://github.com/neondatabase-labs/release-pr-testing/ surfaced two problems:
 - we're running on `ubuntu-22.04` in the neon repo. We have to either adjust the composite action to fetch python, or mark 3.10 as supported. As 3.10 seems to work fine, I've opted for the latter.
 - cherry-picking did not work as expected, because with pipelines things run in subshells. This caused the modification of the args array in the loop to not make it outside of the loop.