### PR TITLE
release-pr: renamed approval parameter fixes + local ref support

### DIFF
--- a/release-pr/action.yml
+++ b/release-pr/action.yml
@@ -13,8 +13,8 @@ inputs:
   auto-merge:
     description: "Enable auto-merge after PR approval"
     required: false
-  auto-approve:
-    description: "Automatically approve the PR"
+  approve:
+    description: "Approve the PR"
     required: false
 
 runs:
@@ -49,8 +49,8 @@ runs:
           neon_release_pr_args+=( --auto-merge )
         fi
 
-        if [[ "${{ inputs.auto-approve }}" == "true" ]]; then
-          neon_release_pr_args+=( --auto-approve )
+        if [[ "${{ inputs.approve }}" == "true" ]]; then
+          neon_release_pr_args+=( --approve )
         fi
 
         read -ra commits <<< "${{ inputs.cherry-pick }}"

--- a/release-pr/src/neon_release_pr/git.py
+++ b/release-pr/src/neon_release_pr/git.py
@@ -64,7 +64,12 @@ def fetch_all():
 
 
 def create_from_remote(base_branch: str, new_branch: str):
-    run_git(["switch", "-c", new_branch, f"origin/{base_branch}"])
+    # Assume the base_branch is a remote branch by default, fall back to local
+    # for branches not pushed to remote or commit hashes
+    try:
+        run_git(["switch", "-c", new_branch, f"origin/{base_branch}"])
+    except Exception:
+        run_git(["switch", "-c", new_branch, base_branch])
 
 
 def switch_to_branch(branch: str):


### PR DESCRIPTION
- **fix(release-pr): reflect renamed approval parameter**
- **fix(release-pr): fall back to local ref if remote ref fails**: This is specifically important for console releases, as they are created from a specific commit, which fails with the previous logic.
