### PR TITLE
neon_release_pr: use `neon-main` for `neon-release-*` branches

### DIFF
--- a/release-pr/src/neon_release_pr/cli.py
+++ b/release-pr/src/neon_release_pr/cli.py
@@ -68,7 +68,7 @@ def new(
     if cherry_pick and base is None:
         base = git.release_branch_name()
     elif base is None:
-        base = "main"
+        base = git.base_branch_name()
 
     branch_name = git.rc_branch_name()
 

--- a/release-pr/src/neon_release_pr/git.py
+++ b/release-pr/src/neon_release_pr/git.py
@@ -164,6 +164,10 @@ def release_branch_name() -> str:
     return release_branch_name_override() or f"release-{ctx.component}"
 
 
+def base_branch_name() -> str:
+    return "neon-main" if release_branch_name().startswith("neon-release-") else "main"
+
+
 def release_branch_name_override() -> str | None:
     overrides = {
         "neondatabase/neon": {


### PR DESCRIPTION
Use `neon-main` for `neon-release-*` branches if `--base` is not set explicitly