### PR TITLE
fix(release-pr): allow cherry-picked commits to be empty

### DIFF
--- a/release-pr/src/neon_release_pr/git.py
+++ b/release-pr/src/neon_release_pr/git.py
@@ -90,7 +90,7 @@ def current_branch() -> str:
 
 def apply_commits(commits: list[str]):
     for commit in commits:
-        run_git(["cherry-pick", commit])
+        run_git(["cherry-pick", "--allow-empty", commit])
 
 
 def get_tree_sha(commit: str) -> str:


### PR DESCRIPTION
Testing the hotfix with empty commits could be convenient