### PR TITLE
feat(release-pr): use uv's Python to run neon-release-pr

### DIFF
--- a/release-pr/action.yml
+++ b/release-pr/action.yml
@@ -29,6 +29,10 @@ runs:
       shell: bash
       run: uv sync --project ${GITHUB_ACTION_PATH}
 
+    - name: Configure git credentials
+      shell: bash
+      run: gh auth setup-git
+
     - name: Run neon-release-pr
       shell: bash
       run: |


### PR DESCRIPTION
Currently, `neondatabase/dev-actions/release-pr` action requires Python and pip to be installed on host.

Currently, `neondatabase/dev-actions/release-pr` action requires Python and pip to be installed on host.

This PR switches to using `uv run --project ...`  to make `neon-release-pr` use the Python provided by `uv`.