### PR TITLE
feat(mutexbot): use from GHCR

### DIFF
--- a/mutexbot/action.yml
+++ b/mutexbot/action.yml
@@ -20,4 +20,4 @@ inputs:
 outputs: {}
 runs:
   using: docker
-  image: docker://docker.io/neondatabase/mutexbot:v0.2.3
+  image: docker://ghcr.io/neondatabase/dev-actions:mutexbot-v0.2.3


### PR DESCRIPTION
Pull the mutexbot image from GHCR instead of Docker Hub, as Docker Hub might get rate-limited.

Ref: LKB-2991