### PR TITLE
mutexbot 0.3.0 follow-ups

### DIFF
--- a/.github/workflows/mutexbot-cleanup.yml
+++ b/.github/workflows/mutexbot-cleanup.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           egress-policy: audit
 
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Delete pre-release for closed PR
         run: |
           echo "Deleting pre-release for PR #${{ github.event.pull_request.number }}"

--- a/.github/workflows/mutexbot.yml
+++ b/.github/workflows/mutexbot.yml
@@ -195,15 +195,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create or update pre-release
-        if: github.ref_type != 'tag'
+        if: github.event_name == 'pull_request'
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            TAG="mutexbot-pr-${{ github.event.pull_request.number }}"
-          elif [[ "${{ github.ref_name }}" == "main" ]]; then
-            TAG="mutexbot-main"
-          else
-            echo "Unsupported pre-release trigger" && exit 1
-          fi
+          TAG="mutexbot-pr-${{ github.event.pull_request.number }}"
 
           # Delete existing pre-release if it exists
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
@@ -222,11 +216,11 @@ jobs:
             --notes "Pre-release for $TAG" \
             mutexbot-*.tar.zst
         env:
-          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test-mutexbot-action:
-    if: github.event_name != 'pull_request' || github.event.action != 'closed'
+    if: github.event_name == 'pull_request' || github.ref_type == 'tag'
     needs: [create-release]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
* 603ace0 **fix(mutexbot): test on PR and tag only**:
  If we run this on both tag and push to main, the tests will access the same resource and will conflict on it.
* cf44454 **fix(mutexbot): fix PR pre-release cleanup**:
  This failed after merging #27, because `gh` expected there to be a git repo checked out.