### PR TITLE
fix(mutexbot): use matching-refs instead of releases to resolve release tag from commit

### DIFF
--- a/mutexbot/Cargo.lock
+++ b/mutexbot/Cargo.lock
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "mutexbot"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/mutexbot/Cargo.toml
+++ b/mutexbot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mutexbot"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 
 [dependencies]

--- a/mutexbot/action.yml
+++ b/mutexbot/action.yml
@@ -41,7 +41,7 @@ runs:
         if [[ "$REF" =~ ^[0-9a-f]{40}$ ]]; then
           echo "Ref is a commit SHA, resolving to release tag..."
     
-          tag=$(gh api repos/neondatabase/dev-actions/releases --paginate | jq -r --arg sha "$REF" 'map(select(.target_commitish == $sha)) | first | .tag_name // error("No release tag found for commit " + $sha)')
+          tag=$(gh api repos/neondatabase/dev-actions/git/matching-refs/tags --paginate | jq -r --arg sha "$REF" 'map(select(.object.sha == $sha)) | first | .ref | ltrimstr("refs/tags/") // error("No release tag found for commit " + $sha)')
     
           echo "tag=$tag" | tee -a "$GITHUB_OUTPUT"
         else


### PR DESCRIPTION
The new action setup from #27 requires github releases for running to fetch pre-built binaries. If the action was pinned to a commit hash, it requires resolving that hash to a git tag. This lookup failed because the `target_commitish` field of a release only sometimes points to a commit, but other times to a branch as well. Our regular releases contain `main` there, causing the lookup to fail.

Instead of using the `releases` API, this PR switches it to use the `matching-refs` API, filtering down to refs that start with `tags/`.

This can still fail to resolve if we try to run from something that's not tagged, or it can successfully resolve to a tag that doesn't belong to mutexbot which means the downloads would fail. In a follow-up we should therefore consider falling back to building locally instead of failing the action.
