### PR TITLE
Updated Mutexbot CLI flow to use DB

### DIFF
--- a/mutexbot/Cargo.toml
+++ b/mutexbot/Cargo.toml
@@ -11,6 +11,7 @@ log = "0.4"
 reqwest = { version = "0.12", features = ["json", "rustls-tls-native-roots"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+tokio-postgres = "0.7"
 
 [build-dependencies]
 anyhow = "1"

--- a/mutexbot/src/main.rs
+++ b/mutexbot/src/main.rs
@@ -7,6 +7,7 @@ use log::info;
 use reqwest::{Client, StatusCode, header};
 use serde::{Deserialize, Serialize};
 use tokio::time::sleep;
+use tokio_postgres::{NoTls, Error as PgError};
 
 pub(crate) mod cli;
 
@@ -100,142 +101,55 @@ async fn main() -> Result<()> {
             notes,
             resource_name,
         } => {
-            let payload = ReservePayload {
-                notes: notes.clone(),
-                duration: duration.clone(),
-                isolation_channel: args.isolation_channel.clone(),
-            };
-            loop {
-                match state
-                    .http
-                    .post(args.mode.api_endpoint())
-                    .json(&payload)
-                    .send()
-                    .await
-                {
-                    Ok(resp) => match resp.status() {
-                        StatusCode::CREATED => {
-                            info!("Resource reserved successfully");
-                            break;
-                        }
-                        StatusCode::CONFLICT => {
-                            info!("Resource already reserved, fetching reservation data.");
-                            match state
-                                .http
-                                .get("https://mutexbot.com/api/resources")
-                                .send()
-                                .await
-                            {
-                                Ok(resp) => match resp.status() {
-                                    StatusCode::OK => {
-                                        let resource = resp
-                                            .json::<Vec<ResourceListItem>>()
-                                            .await?
-                                            .into_iter()
-                                            .find(|resource| {
-                                                &resource.name == resource_name
-                                                    && (args.isolation_channel.is_none()
-                                                        || (resource.isolated
-                                                            && resource.isolation_channel_name
-                                                                == args.isolation_channel))
-                                            })
-                                            .context("Could not find resource!")?;
-                                        if resource.active_reservation.is_none() {
-                                            info!("No active reservation.");
-                                        } else {
-                                            let user = resource.active_reservation_user_name.context("Resource doesn't have active_reservation_user_name!")?;
-                                            let reason = resource.active_reservation_reason.context("Resource doesn't have active_reservation_reason!")?;
+            let region = args.isolation_channel.clone().unwrap_or_else(|| "default".to_string());
 
-                                            if let Some(workflow_url) =
-                                                reason.split_whitespace().last()
-                                            {
-                                                if workflow_url.contains("/actions/runs/") {
-                                                    info!(
-                                                        "Existing reservation by component {user} in {workflow_url}"
-                                                    );
-                                                } else {
-                                                    info!(
-                                                        "Existing reservation by user {user} with reason \"{reason}\""
-                                                    );
-                                                }
-                                            } else {
-                                                info!(
-                                                    "Existing reservation by user {user} with reason \"{reason}\""
-                                                );
-                                            }
-                                        }
-                                    }
-                                    StatusCode::BAD_REQUEST => {
-                                        anyhow::bail!("Bad request. Check your input data.");
-                                    }
-                                    StatusCode::UNAUTHORIZED => {
-                                        anyhow::bail!("Unauthorized. Check your API keys.");
-                                    }
-                                    status_code => state
-                                        .status_code(status_code)
-                                        .await
-                                        .context("Failure creating missing resource")?,
-                                },
-                                Err(error) => state
-                                    .request_failure(error)
-                                    .await
-                                    .context("Failure fetching resource data")?,
+            // Create a single database connection for all operations
+            let db_client = match create_db_connection().await {
+                Ok(client) => client,
+                Err(e) => {
+                    log::error!("Failed to connect to database: {}", e);
+                    anyhow::bail!("Database connection failed: {}", e);
+                }
+            };
+
+            // Insert deployment record into database
+            let deployment_id = match insert_deployment_record(
+                &db_client,
+                notes,
+                resource_name,
+                &region,
+            ).await {
+                Ok(id) => id,
+                Err(e) => {
+                    log::error!("Failed to insert deployment record: {}", e);
+                    anyhow::bail!("Database insertion failed: {}", e);
+                }
+            };
+
+            loop {
+                // Check for blocking deployments in the same region
+                match check_blocking_deployments(&db_client, deployment_id, resource_name, &region).await {
+                    Ok(blocking_deployments) => {
+                        if blocking_deployments.is_empty() {
+                            info!("No blocking deployments found. Resource can be reserved.");
+
+                            //TO DO: Update deployment record to set start_timestamp
+                            break;
+                        } else {
+                            // Print information about blocking deployments
+                            info!("Found {} blocking deployment(s) in region '{}' with smaller queue positions:", 
+                                blocking_deployments.len(), region);
+                            for (id, component) in &blocking_deployments {
+                                info!("  - Deployment ID: {}, Component: {}", id, component);
                             }
                             info!("Retrying in 5 seconds.");
                             sleep(BUSY_RETRY).await;
                         }
-                        StatusCode::BAD_REQUEST => {
-                            anyhow::bail!("Bad request. Check your input data.");
-                        }
-                        StatusCode::UNAUTHORIZED => {
-                            anyhow::bail!("Unauthorized. Check your API keys.");
-                        }
-                        StatusCode::NOT_FOUND => {
-                            info!("Resource not found.");
-                            match state
-                                .http
-                                .post("https://mutexbot.com/api/resources")
-                                .json(&CreatePayload {
-                                    name: resource_name.clone(),
-                                    isolation_channel: args.isolation_channel.clone(),
-                                })
-                                .send()
-                                .await
-                            {
-                                Ok(resp) => match resp.status() {
-                                    StatusCode::CREATED => {
-                                        info!("Resource created")
-                                    }
-                                    StatusCode::CONFLICT => {
-                                        info!("Resource already exists, trying again.");
-                                    }
-                                    StatusCode::BAD_REQUEST => {
-                                        anyhow::bail!("Bad request. Check your input data.");
-                                    }
-                                    StatusCode::UNAUTHORIZED => {
-                                        anyhow::bail!("Unauthorized. Check your API keys.");
-                                    }
-                                    status_code => state
-                                        .status_code(status_code)
-                                        .await
-                                        .context("Failure creating missing resource")?,
-                                },
-                                Err(error) => state
-                                    .request_failure(error)
-                                    .await
-                                    .context("Failure creating missing resource")?,
-                            }
-                        }
-                        status_code => state
-                            .status_code(status_code)
-                            .await
-                            .context("Failure reserving resource")?,
-                    },
-
-                    Err(error) => state
-                        .request_failure(error)
-                        .await
-                        .context("Failure reserving resource")?,
+                    }
+                    Err(e) => {
+                        log::error!("Failed to check blocking deployments: {}", e);
+                        anyhow::bail!("Database query failed: {}", e);
+                    }
                 }
             }
         }
@@ -286,4 +200,73 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Create a database connection and return the client
+async fn create_db_connection() -> Result<tokio_postgres::Client, PgError> {
+    // Database connection configuration
+    let db_config = "host=ep-tiny-bonus-a2qksa7f-pooler.eu-central-1.aws.neon.tech user=neondb_owner password=npg_RQzVs7DbYrU2 dbname=neondb";
+    
+    // Connect to the database
+    let (client, connection) = tokio_postgres::connect(db_config, NoTls).await?;
+    
+    // Spawn the connection on a separate task
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("Database connection error: {}", e);
+        }
+    });
+    
+    Ok(client)
+}
+
+/// Insert a new deployment record into the PostgreSQL database and return the ID
+async fn insert_deployment_record(
+    client: &tokio_postgres::Client,
+    note: &str,
+    component: &str,
+    region: &str,
+) -> Result<i64, PgError> {
+    // Insert the deployment record and return the ID
+    let query = "INSERT INTO deployments (note, component, region) VALUES ($1, $2, $3) RETURNING id";
+    
+    let row = client.query_one(query, &[&note, &component, &region]).await?;
+    let deployment_id: i64 = row.get(0);
+    
+    log::info!("Successfully inserted deployment record: id={}, component={}, region={}", deployment_id, component, region);
+    
+    Ok(deployment_id)
+}
+
+/// Check for blocking deployments in the same region
+async fn check_blocking_deployments(
+    client: &tokio_postgres::Client,
+    deployment_id: i64,
+    component: &str,
+    region: &str,
+) -> Result<Vec<(i64, String)>, PgError> {
+    // Query for deployments in the same region by other components with smaller ID (queue position)
+    // that haven't finished yet (finish_timestamp IS NULL)
+    let query = "
+        SELECT id, component 
+        FROM deployments 
+        WHERE region = $1 
+          AND component != $2 
+          AND id < $3 
+          AND finish_timestamp IS NULL
+        ORDER BY id ASC
+    ";
+    
+    let rows = client.query(query, &[&region, &component, &deployment_id]).await?;
+    
+    let blocking_deployments: Vec<(i64, String)> = rows
+        .into_iter()
+        .map(|row| {
+            let id: i64 = row.get(0);
+            let component: String = row.get(1);
+            (id, component)
+        })
+        .collect();
+    
+    Ok(blocking_deployments)
 }


### PR DESCRIPTION
Related to https://databricks.atlassian.net/browse/LKB-3161.

Update Mutexbot CLI flow to use DB for reservation instead of API.
First version:
 - Enter queue
 - Loop to check existing reservation