### PR TITLE
Introduce reserve-exclusive to wait for a resource.

### DIFF
--- a/mutexbot/Cargo.lock
+++ b/mutexbot/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +96,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
@@ -160,6 +175,20 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link 0.2.0",
+]
 
 [[package]]
 name = "clap"
@@ -513,6 +542,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,13 +811,24 @@ name = "mutexbot"
 version = "0.3.2"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "clap_allgen",
  "env_logger",
  "log",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "tokio",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -883,7 +947,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -926,12 +990,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -941,7 +1026,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1618,10 +1712,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.0",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link 0.2.0",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1672,7 +1825,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/mutexbot/Cargo.toml
+++ b/mutexbot/Cargo.toml
@@ -5,9 +5,11 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
 env_logger = "0.11"
 log = "0.4"
+rand = "0.8"
 reqwest = { version = "0.12", features = ["json", "rustls-tls-native-roots"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/mutexbot/action.yml
+++ b/mutexbot/action.yml
@@ -4,7 +4,7 @@ inputs:
   api_key:
     description: Mutexbot API key
   mode:
-    description: Whether to reserve or release or force-release
+    description: Whether to reserve, reserve-exclusive, release, or force-release
     default: reserve
   resource_name:
     description: Mutexbot resource name
@@ -87,6 +87,17 @@ runs:
           "reserve")
             args+=(
               "reserve"
+              "${RESOURCE_NAME}"
+              "Reserved by ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            )
+            if [[ -n "${DURATION}" ]]; then
+              args+=( "${DURATION}" )
+            fi
+            mutexbot "${args[@]}"
+            ;;
+          "reserve-exclusive")
+            args+=(
+              "reserve-exclusive"
               "${RESOURCE_NAME}"
               "Reserved by ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
             )

--- a/mutexbot/src/cli.rs
+++ b/mutexbot/src/cli.rs
@@ -26,6 +26,17 @@ pub(crate) enum Mode {
         /// Duration to reserve resource for. Defaults to value set in MutexBot if omitted
         duration: Option<String>,
     },
+    /// Reserve a resource exclusively (wait for existing reservations to expire)
+    ///
+    /// Use the `MUTEXBOT_API_KEY` environment variable to pass the API key.
+    ReserveExclusive {
+        /// Resource to reserve
+        resource_name: String,
+        /// Notes for this reservation
+        notes: String,
+        /// Duration to reserve resource for. Defaults to value set in MutexBot if omitted
+        duration: Option<String>,
+    },
     /// Release a resource
     ///
     /// Use the `MUTEXBOT_API_KEY` environment variable to pass the API key.
@@ -46,6 +57,10 @@ impl Mode {
     pub(crate) fn api_endpoint(&self) -> String {
         match self {
             Mode::Reserve { resource_name, .. } => format!(
+                "https://mutexbot.com/api/resources/global/{}/reserve",
+                resource_name,
+            ),
+            Mode::ReserveExclusive { resource_name, .. } => format!(
                 "https://mutexbot.com/api/resources/global/{}/reserve",
                 resource_name,
             ),

--- a/mutexbot/src/main.rs
+++ b/mutexbot/src/main.rs
@@ -1,9 +1,11 @@
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
 use clap::Parser;
 use cli::Mode;
 use log::info;
+use rand::Rng;
 use reqwest::{Client, StatusCode, header};
 use serde::{Deserialize, Serialize};
 use tokio::time::sleep;
@@ -87,6 +89,238 @@ struct ResourceListItem {
 const FAILURE_RETRY: Duration = Duration::from_secs(2);
 const BUSY_RETRY: Duration = Duration::from_secs(5);
 
+impl State {
+    /// Fetch resource data from the API and find a specific resource.
+    /// Returns `Ok(None)` if the resource is not found.
+    async fn fetch_resource_data(
+        &mut self,
+        resource_name: &str,
+        isolation_channel: &Option<String>,
+    ) -> Result<Option<ResourceListItem>> {
+        match self.http.get("https://mutexbot.com/api/resources").send().await {
+            Ok(resp) => match resp.status() {
+                StatusCode::OK => {
+                    let resources = resp.json::<Vec<ResourceListItem>>().await?;
+                    Ok(resources.into_iter().find(|resource| {
+                        &resource.name == resource_name
+                            && (isolation_channel.is_none()
+                                || (resource.isolated
+                                    && resource.isolation_channel_name == *isolation_channel))
+                    }))
+                }
+                StatusCode::BAD_REQUEST => {
+                    anyhow::bail!("Bad request. Check your input data.");
+                }
+                StatusCode::UNAUTHORIZED => {
+                    anyhow::bail!("Unauthorized. Check your API keys.");
+                }
+                status_code => {
+                    self.status_code(status_code)
+                        .await
+                        .context("Failure fetching resource data")?;
+                    Err(anyhow::anyhow!("Retry needed"))
+                }
+            },
+            Err(error) => {
+                self.request_failure(error)
+                    .await
+                    .context("Failure fetching resource data")?;
+                Err(anyhow::anyhow!("Retry needed"))
+            }
+        }
+    }
+
+    /// Create a resource when it doesn't exist.
+    async fn create_resource_if_missing(
+        &mut self,
+        resource_name: &str,
+        isolation_channel: &Option<String>,
+    ) -> Result<()> {
+        info!("Resource not found, creating it.");
+        match self
+            .http
+            .post("https://mutexbot.com/api/resources")
+            .json(&CreatePayload {
+                name: resource_name.to_string(),
+                isolation_channel: isolation_channel.clone(),
+            })
+            .send()
+            .await
+        {
+            Ok(resp) => match resp.status() {
+                StatusCode::CREATED => {
+                    info!("Resource created");
+                    Ok(())
+                }
+                StatusCode::CONFLICT => {
+                    info!("Resource already exists, trying again.");
+                    Ok(())
+                }
+                StatusCode::BAD_REQUEST => {
+                    anyhow::bail!("Bad request. Check your input data.");
+                }
+                StatusCode::UNAUTHORIZED => {
+                    anyhow::bail!("Unauthorized. Check your API keys.");
+                }
+                status_code => {
+                    self.status_code(status_code)
+                        .await
+                        .context("Failure creating missing resource")?;
+                    Err(anyhow::anyhow!("Retry needed"))
+                }
+            },
+            Err(error) => {
+                self.request_failure(error)
+                    .await
+                    .context("Failure creating missing resource")?;
+                Err(anyhow::anyhow!("Retry needed"))
+            }
+        }
+    }
+
+
+
+    /// Attempt to reserve a resource and handle common status codes.
+    async fn attempt_reservation(
+        &mut self,
+        endpoint: &str,
+        payload: &ReservePayload,
+        resource_name: &str,
+        isolation_channel: &Option<String>,
+    ) -> Result<ReservationResult> {
+        match self.http.post(endpoint).json(payload).send().await {
+            Ok(resp) => match resp.status() {
+                StatusCode::CREATED => {
+                    info!("Resource reserved successfully");
+                    Ok(ReservationResult::Success)
+                }
+                StatusCode::CONFLICT => Ok(ReservationResult::Conflict),
+                StatusCode::BAD_REQUEST => {
+                    anyhow::bail!("Bad request. Check your input data.");
+                }
+                StatusCode::UNAUTHORIZED => {
+                    anyhow::bail!("Unauthorized. Check your API keys.");
+                }
+                StatusCode::NOT_FOUND => {
+                    self.create_resource_if_missing(resource_name, isolation_channel)
+                        .await?;
+                    Ok(ReservationResult::Retry)
+                }
+                status_code => {
+                    self.status_code(status_code)
+                        .await
+                        .context("Failure reserving resource")?;
+                    Ok(ReservationResult::Retry)
+                }
+            },
+            Err(error) => {
+                self.request_failure(error)
+                    .await
+                    .context("Failure reserving resource")?;
+                Ok(ReservationResult::Retry)
+            }
+        }
+    }
+}
+
+/// Log information about an existing reservation.
+fn log_reservation_info(resource: &ResourceListItem) -> Result<()> {
+    if resource.active_reservation.is_none() {
+        info!("No active reservation.");
+        return Ok(());
+    }
+    let user = resource
+        .active_reservation_user_name
+        .as_ref()
+        .context("Resource doesn't have active_reservation_user_name!")?;
+    let reason = resource
+        .active_reservation_reason
+        .as_ref()
+        .context("Resource doesn't have active_reservation_reason!")?;
+
+    // Build the basic reservation message.
+    let base_message = if let Some(workflow_url) = reason.split_whitespace().last() {
+        if workflow_url.contains("/actions/runs/") {
+            format!("Existing reservation by component {user} in {workflow_url}")
+        } else {
+            format!("Existing reservation by user {user} with reason \"{reason}\"")
+        }
+    } else {
+        format!("Existing reservation by user {user} with reason \"{reason}\"")
+    };
+
+    // Add expiration information if available.
+    if let Some(expires_at) = parse_expiration_time(&resource.active_reservation) {
+        info!("{}. Expires at: {}.", base_message, expires_at);
+    } else {
+        info!("{}.", base_message);
+    }
+    Ok(())
+}
+
+/// Check if a resource has an active (non-expired) reservation.
+fn has_active_reservation(resource: &ResourceListItem) -> bool {
+    if resource.active_reservation.is_none() {
+        return false;
+    }
+
+    // If we can parse the expiration time, check if it's in the future.
+    if let Some(expires_at) = parse_expiration_time(&resource.active_reservation) {
+        return expires_at > Utc::now();
+    }
+    // Conservatively assume the reservation is still active.
+    true
+}
+
+/// Parse expiration time in a resource.
+fn parse_expiration_time(active_reservation: &Option<String>) -> Option<DateTime<Utc>> {
+    match active_reservation {
+        Some(timestamp) => {
+            match DateTime::parse_from_rfc3339(timestamp.as_str()) {
+                Ok(datetime) => Some(datetime.with_timezone(&Utc)),
+                Err(_) => {
+                    info!("Active reservation {} is not a valid ISO 8601 timestamp", timestamp);
+                    None
+                }
+            }
+        },
+        _ => None,
+    }
+}
+
+/// Calculate wait time based on reservation expiration.
+fn calculate_wait_time(resource: &ResourceListItem) -> Duration {
+    let max_wait = Duration::from_secs(5 * 60);
+    let no_wait = Duration::from_secs(1);
+
+    // Try to parse expiration time from various possible fields.
+    let expiration_time = parse_expiration_time(&resource.active_reservation);
+    
+    let base_wait = match expiration_time {
+        None => no_wait,
+        Some(expires_at) => {
+            let now = Utc::now();
+            if expires_at > now {
+                let time_until_expiration = (expires_at - now).to_std().unwrap_or(Duration::ZERO);
+                return std::cmp::min(time_until_expiration, max_wait);
+            }
+            return no_wait;
+        }
+    };
+
+    // Pick a random duration between [base_wait, base_wait * 1.3333].
+    let jitter_range = base_wait.as_millis() as u64 / 3;
+    let jitter_offset = rand::thread_rng().gen_range(0..=jitter_range);
+    base_wait + Duration::from_millis(jitter_offset)
+}
+
+#[derive(Debug)]
+enum ReservationResult {
+    Success,
+    Conflict,
+    Retry,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let log_env = env_logger::Env::default().filter_or("MUTEXBOT_LOG_LEVEL", "info");
@@ -105,137 +339,91 @@ async fn main() -> Result<()> {
                 duration: duration.clone(),
                 isolation_channel: args.isolation_channel.clone(),
             };
+            
             loop {
                 match state
-                    .http
-                    .post(args.mode.api_endpoint())
-                    .json(&payload)
-                    .send()
-                    .await
+                    .attempt_reservation(&args.mode.api_endpoint(), &payload, resource_name, &args.isolation_channel)
+                    .await?
                 {
-                    Ok(resp) => match resp.status() {
-                        StatusCode::CREATED => {
-                            info!("Resource reserved successfully");
-                            break;
-                        }
-                        StatusCode::CONFLICT => {
-                            info!("Resource already reserved, fetching reservation data.");
-                            match state
-                                .http
-                                .get("https://mutexbot.com/api/resources")
-                                .send()
-                                .await
-                            {
-                                Ok(resp) => match resp.status() {
-                                    StatusCode::OK => {
-                                        let resource = resp
-                                            .json::<Vec<ResourceListItem>>()
-                                            .await?
-                                            .into_iter()
-                                            .find(|resource| {
-                                                &resource.name == resource_name
-                                                    && (args.isolation_channel.is_none()
-                                                        || (resource.isolated
-                                                            && resource.isolation_channel_name
-                                                                == args.isolation_channel))
-                                            })
-                                            .context("Could not find resource!")?;
-                                        if resource.active_reservation.is_none() {
-                                            info!("No active reservation.");
-                                        } else {
-                                            let user = resource.active_reservation_user_name.context("Resource doesn't have active_reservation_user_name!")?;
-                                            let reason = resource.active_reservation_reason.context("Resource doesn't have active_reservation_reason!")?;
-
-                                            if let Some(workflow_url) =
-                                                reason.split_whitespace().last()
-                                            {
-                                                if workflow_url.contains("/actions/runs/") {
-                                                    info!(
-                                                        "Existing reservation by component {user} in {workflow_url}"
-                                                    );
-                                                } else {
-                                                    info!(
-                                                        "Existing reservation by user {user} with reason \"{reason}\""
-                                                    );
-                                                }
-                                            } else {
-                                                info!(
-                                                    "Existing reservation by user {user} with reason \"{reason}\""
-                                                );
-                                            }
-                                        }
-                                    }
-                                    StatusCode::BAD_REQUEST => {
-                                        anyhow::bail!("Bad request. Check your input data.");
-                                    }
-                                    StatusCode::UNAUTHORIZED => {
-                                        anyhow::bail!("Unauthorized. Check your API keys.");
-                                    }
-                                    status_code => state
-                                        .status_code(status_code)
-                                        .await
-                                        .context("Failure creating missing resource")?,
-                                },
-                                Err(error) => state
-                                    .request_failure(error)
-                                    .await
-                                    .context("Failure fetching resource data")?,
+                    ReservationResult::Success => break,
+                    ReservationResult::Conflict => {
+                        info!("Resource already reserved, fetching reservation data.");
+                        match state.fetch_resource_data(resource_name, &args.isolation_channel).await {
+                            Ok(Some(resource)) => {
+                                log_reservation_info(&resource)?;
                             }
-                            info!("Retrying in 5 seconds.");
-                            sleep(BUSY_RETRY).await;
-                        }
-                        StatusCode::BAD_REQUEST => {
-                            anyhow::bail!("Bad request. Check your input data.");
-                        }
-                        StatusCode::UNAUTHORIZED => {
-                            anyhow::bail!("Unauthorized. Check your API keys.");
-                        }
-                        StatusCode::NOT_FOUND => {
-                            info!("Resource not found.");
-                            match state
-                                .http
-                                .post("https://mutexbot.com/api/resources")
-                                .json(&CreatePayload {
-                                    name: resource_name.clone(),
-                                    isolation_channel: args.isolation_channel.clone(),
-                                })
-                                .send()
-                                .await
-                            {
-                                Ok(resp) => match resp.status() {
-                                    StatusCode::CREATED => {
-                                        info!("Resource created")
-                                    }
-                                    StatusCode::CONFLICT => {
-                                        info!("Resource already exists, trying again.");
-                                    }
-                                    StatusCode::BAD_REQUEST => {
-                                        anyhow::bail!("Bad request. Check your input data.");
-                                    }
-                                    StatusCode::UNAUTHORIZED => {
-                                        anyhow::bail!("Unauthorized. Check your API keys.");
-                                    }
-                                    status_code => state
-                                        .status_code(status_code)
-                                        .await
-                                        .context("Failure creating missing resource")?,
-                                },
-                                Err(error) => state
-                                    .request_failure(error)
-                                    .await
-                                    .context("Failure creating missing resource")?,
+                            _ => {
+                                info!("Could not find resource after conflict.");
                             }
                         }
-                        status_code => state
-                            .status_code(status_code)
-                            .await
-                            .context("Failure reserving resource")?,
-                    },
+                        info!("Retrying in {} seconds.", BUSY_RETRY.as_secs());
+                        sleep(BUSY_RETRY).await;
+                    }
+                    ReservationResult::Retry => {
+                        // Continue the loop for retry.
+                    }
+                }
+            }
+        }
+        Mode::ReserveExclusive {
+            duration,
+            notes,
+            resource_name,
+        } => {
+            let payload = ReservePayload {
+                notes: notes.clone(),
+                duration: duration.clone(),
+                isolation_channel: args.isolation_channel.clone(),
+            };
 
-                    Err(error) => state
-                        .request_failure(error)
-                        .await
-                        .context("Failure reserving resource")?,
+            loop {
+                // First, check if resource exists (create it if it doesn't) and has an active reservation.
+                let resource_data = match state.fetch_resource_data(resource_name, &args.isolation_channel).await {
+                    Ok(data) => data,
+                    Err(_) => continue,
+                };
+
+                if resource_data.is_none() {
+                    if let Err(_) = state.create_resource_if_missing(resource_name, &args.isolation_channel).await {
+                        continue;
+                    }
+                }
+
+                // Check if there's an active (non-expired) reservation.
+                if let Some(resource) = resource_data && has_active_reservation(&resource) {
+                    log_reservation_info(&resource)?;
+
+                    // Calculate wait time based on reservation expiration.
+                    let wait_time = calculate_wait_time(&resource);
+                    info!("Resource is reserved, waiting {:.1} seconds before retrying...",
+                            wait_time.as_secs_f64());
+                    sleep(wait_time).await;
+                    continue;
+                }
+
+                match state
+                    .attempt_reservation(&args.mode.api_endpoint(), &payload, resource_name, &args.isolation_channel)
+                    .await?
+                {
+                    ReservationResult::Success => break,
+                    ReservationResult::Conflict => {
+                        // Another process reserved it between our check and reservation attempt.
+                        info!("Resource became reserved between check and reservation attempt");
+                        
+                        // Fetch updated resource data to get expiration info for smart wait
+                        let wait_time = match state.fetch_resource_data(resource_name, &args.isolation_channel).await {
+                            Ok(Some(resource)) => calculate_wait_time(&resource),
+                            _ => {
+                                // Fallback to short wait if we can't fetch resource data.
+                                Duration::from_millis(rand::thread_rng().gen_range(1000..=5000))
+                            }
+                        };
+                        info!("Waiting {:.1} seconds before retrying...", wait_time.as_secs_f64());
+                        sleep(wait_time).await;
+                    }
+                    ReservationResult::Retry => {
+                        // Continue the loop for retry.
+                    }
                 }
             }
         }

--- a/mutexbot/src/main.rs
+++ b/mutexbot/src/main.rs
@@ -390,15 +390,18 @@ async fn main() -> Result<()> {
                 }
 
                 // Check if there's an active (non-expired) reservation.
-                if let Some(resource) = resource_data && has_active_reservation(&resource) {
-                    log_reservation_info(&resource)?;
+                if let Some(resource) = resource_data {
+                
+                    if has_active_reservation(&resource) {
+                        log_reservation_info(&resource)?;
 
-                    // Calculate wait time based on reservation expiration.
-                    let wait_time = calculate_wait_time(&resource);
-                    info!("Resource is reserved, waiting {:.1} seconds before retrying...",
-                            wait_time.as_secs_f64());
-                    sleep(wait_time).await;
-                    continue;
+                        // Calculate wait time based on reservation expiration.
+                        let wait_time = calculate_wait_time(&resource);
+                        info!("Resource is reserved, waiting {:.1} seconds before retrying...",
+                                wait_time.as_secs_f64());
+                        sleep(wait_time).await;
+                        continue;
+                    }
                 }
 
                 match state


### PR DESCRIPTION
Mutexbot API semantics allow the `reserve` API call to silently update an existing reservation. This makes it hard to use `mutexbot` as a concurrency control mechanism in GitHub workflows that share the same API key.

This PR introduces a new mode for mutexbot, called `reserve-exclusive`. This new mode checks for the existence of active reservations before trying to reserve a resource. If an active reservation exists, the code keeps checking periodically, until it is finally able to get a reservation.

Example output:

```shell
$ ./mutexbot reserve-exclusive test-resource "" "1m"
[2025-09-17T13:54:36Z INFO  mutexbot] Resource reserved successfully

$ ./mutexbot reserve-exclusive test-resource "" "1m"
[2025-09-17T13:54:39Z INFO  mutexbot] Existing reservation by user testBot with reason "". Expires at: 2025-09-17 13:55:36.455 UTC.
[2025-09-17T13:54:39Z INFO  mutexbot] Resource is reserved, waiting 57.0 seconds before retrying...
[2025-09-17T13:55:37Z INFO  mutexbot] Resource reserved successfully
```