### PR TITLE
SHA-pin actions in release-pr-notify; bump to org-standard versions

### DIFF
--- a/release-pr-notify/action.yml
+++ b/release-pr-notify/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
       - name: Generate Slack Message
         id: generate-slack-message
-        uses: actions/github-script@v6
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           retries: 5
           result-encoding: string
@@ -26,14 +26,14 @@ runs:
             return await script({ github, context })
 
       - name: Get a file with Slack message ID from GitHub Actions cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: release-notify.json
           key: release-pr-notify-${{ github.event.number }}.json
 
       - name: Get a file with Slack message ID from GitHub Actions cache (fallback)
         id: posted-message-fallback
-        uses: actions/github-script@v6
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           retries: 5
           result-encoding: string
@@ -72,7 +72,7 @@ runs:
 
       - name: Send Slack message
         id: slack
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
         with:
           channel-id: ${{ inputs.slack-channel-id }}
           update-ts: ${{ steps.message.outputs.update-ts }}
@@ -88,14 +88,14 @@ runs:
 
       - name: Save a file with Slack message ID to GitHub Actions cache
         if: steps.message.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: release-notify.json
           key: release-pr-notify-${{ github.event.number }}.json${{ steps.slack.outputs.ts }}
 
       - name: Delete a file with Slack message ID from GitHub Actions cache
         if: always() && github.event.action == 'closed'
-        uses: actions/github-script@v6
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           retries: 5
           script: |


### PR DESCRIPTION
## Summary

Replace tag-only action refs in `release-pr-notify/action.yml` with full-SHA pins, matching the versions already in use across sibling Neon repos (`neon-cloud`, `hadron`).

| Action | Before | After |
|---|---|---|
| `actions/github-script` | `@v6` | `@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8` |
| `actions/cache/restore` | `@v3` | `@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3` |
| `actions/cache/save` | `@v3` | `@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3` |
| `slackapi/slack-github-action` | `@v1` | `@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1` |

## Why

- Tag refs (`@v6`, `@v3`, `@v1`) are **mutable**. An attacker who compromises the upstream publisher (or GitHub) can silently flip them to malicious commits. SHA pins remove that class of risk.
- `actions/cache@v3` was deprecated by GitHub in Feb 2025 and the cache service returns 400s for new calls — staying on v3 means this step is effectively broken.
- `github-script@v8` and `cache@v5.0.3` are what `neon-cloud` and `hadron` are already using in production CI, so we get consistency across Neon repos.
- Kept `slack-github-action` on **v1.27.1** (SHA-pinned) instead of bumping to v3 — v2/v3 introduced a breaking payload API change (`method: chat.postMessage` etc.) that would require rewriting the Slack step. That can be a follow-up PR.

## Compatibility notes

- `github-script` v6→v8: runs on Node 20, Octokit v21+. The existing `github.rest.*` + `github.paginate(...)` calls still work unchanged.
- `cache` v3→v5: v3 cache entries are not readable by v5, so the `release-pr-notify` action will miss its cache on first run per open PR. The existing `posted-message-fallback` step (which queries the GH API cache list) covers this, so there is no functional break — just a one-time re-post per in-flight PR at merge time.

## Test plan

- [ ] CI on this PR passes `release-pr` workflow (doesn't exercise this action, but sanity check)
- [ ] Open a test release PR using this action and verify the Slack message is posted
- [ ] Trigger a second run on the same PR and verify the existing Slack message is **updated**, not reposted (exercises the cache save/restore flow)
- [ ] Close the test PR and verify the cache-delete step runs without error

## Context

Part of a supply-chain security audit of `neondatabase/dev-actions`. Companion items (not in this PR):
- Enable branch protection on `main`
- Digest-pin base images in `deploy-queue/Dockerfile`
- Add `.github/dependabot.yml` for automated version-bump PRs
- Consider `harden-runner` `egress-policy: block` (will require allowlisting StepSecurity API, since the neondatabase org IP allowlist blocks those runners from reaching it today)

This pull request and its description were written by Isaac.